### PR TITLE
Add missing closing brace to Keyboard.press() example code

### DIFF
--- a/Language/Functions/USB/Keyboard/keyboardPress.adoc
+++ b/Language/Functions/USB/Keyboard/keyboardPress.adoc
@@ -79,6 +79,7 @@ void loop() {
   Keyboard.releaseAll();
   // wait for new window to open:
   delay(1000);
+}
 ----
 
 --


### PR DESCRIPTION
Fixes https://github.com/arduino/reference-ko/issues/122