### PR TITLE
Fixing sizeof doesn't highlight sizeof keyword

### DIFF
--- a/Language/Variables/Utilities/sizeof.adoc
+++ b/Language/Variables/Utilities/sizeof.adoc
@@ -12,7 +12,7 @@ subCategories: [ "유틸리티" ]
 
 [float]
 === 설명
-sizeof 연산자는 변수 형의 바이트 수, 또는 배열이 점유하는 바이트 수를 반환한다.
+`sizeof` 연산자는 변수 형의 바이트 수, 또는 배열이 점유하는 바이트 수를 반환한다.
 [%hardbreaks]
 
 [float]


### PR DESCRIPTION
Fixes https://github.com/arduino/reference-en/issues/437

Fixes https://github.com/arduino/reference-ko/issues/131