### PR TITLE
Got rid of the quote characters in visible on the Arduino website

### DIFF
--- a/Language/Functions/Characters/isAlphaNumeric.adoc
+++ b/Language/Functions/Characters/isAlphaNumeric.adoc
@@ -25,7 +25,7 @@ subCategories: [ "문자" ]
 === 문법
 [source,arduino]
 ----
-`isAlphaNumeric(thisChar)`
+isAlphaNumeric(thisChar)
 ----
 
 [float]

--- a/Language/Functions/Characters/isWhitespace.adoc
+++ b/Language/Functions/Characters/isWhitespace.adoc
@@ -25,7 +25,7 @@ thisChar가 공백 문자이면 true를 반환합니다.
 [float]
 === 문법
 [source,arduino]
-`isWhitespace(thisChar)`
+isWhitespace(thisChar)
 
 [float]
 === 매개변수


### PR DESCRIPTION
On the Arduino reference guide, there are quotes around the function Syntaxis, this might confuse the user, especially since it is not consistent, and present when copy pasting it.

Fixes https://github.com/arduino/reference-ko/issues/143