### PR TITLE
Modified wrong word.

### DIFF
--- a/Language/Functions/USB/Mouse/mouseMove.adoc
+++ b/Language/Functions/USB/Mouse/mouseMove.adoc
@@ -22,7 +22,7 @@ title: Mouse.move()
 
 [float]
 === 문법
-`Mouse.move(xVal, yPos, wheel);`
+`Mouse.move(xVal, yVal, wheel);`
 
 
 [float]


### PR DESCRIPTION
yPos -> yVal

Fixes https://github.com/arduino/reference-ko/issues/149