### PR TITLE
Remove Language labels from description text

### DIFF
--- a/Language/Functions/Communication/Stream/streamFindUntil.adoc
+++ b/Language/Functions/Communication/Stream/streamFindUntil.adoc
@@ -18,7 +18,7 @@ title: Stream.findUntil()
 
 The function returns true if target string is found, false if timed out
 
-This function is part of the Stream class, and is called by any class that inherits from it (Wire, Serial, etc). See the #LANGUAGE# link:../../stream[Stream class] main page for more information.
+This function is part of the Stream class, and is called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[Stream class] main page for more information.
 [%hardbreaks]
 
 

--- a/Language/Functions/Communication/Stream/streamSetTimeout.adoc
+++ b/Language/Functions/Communication/Stream/streamSetTimeout.adoc
@@ -14,7 +14,7 @@ title: Stream.setTimeout()
 
 [float]
 === 설명
-`setTimeout()` sets the maximum milliseconds to wait for stream data, it defaults to 1000 milliseconds. This function is part of the Stream class, and is called by any class that inherits from it (Wire, Serial, etc). See the #LANGUAGE# link:../../stream[Stream class] main page for more information.
+`setTimeout()` sets the maximum milliseconds to wait for stream data, it defaults to 1000 milliseconds. This function is part of the Stream class, and is called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[Stream class] main page for more information.
 [%hardbreaks]
 
 


### PR DESCRIPTION
Placing these labels in the description text is inconsistent with all the other reference pages and doesn't provide any benefit.

Fixes https://github.com/arduino/reference-ko/issues/153