### PR TITLE
Add missing "See also" sections

### DIFF
--- a/Language/Functions/Advanced IO/noTone.adoc
+++ b/Language/Functions/Advanced IO/noTone.adoc
@@ -52,3 +52,14 @@ aliases: [ /language/functions/advanced-io/noTone/ ]
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== See also
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Advanced IO/pulseIn.adoc
+++ b/Language/Functions/Advanced IO/pulseIn.adoc
@@ -79,3 +79,14 @@ void loop()
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== See also
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Advanced IO/pulseInLong.adoc
+++ b/Language/Functions/Advanced IO/pulseInLong.adoc
@@ -81,3 +81,14 @@ void loop() {
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== See also
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Advanced IO/shiftIn.adoc
+++ b/Language/Functions/Advanced IO/shiftIn.adoc
@@ -48,3 +48,14 @@ subCategories: [ "고급 입출력" ]
 
 --
 // OVERVIEW SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== See also
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Advanced IO/shiftOut.adoc
+++ b/Language/Functions/Advanced IO/shiftOut.adoc
@@ -125,3 +125,14 @@ shiftOut(dataPin, clock, LSBFIRST, (data >> 8));
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== See also
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Bits and Bytes/bit.adoc
+++ b/Language/Functions/Bits and Bytes/bit.adoc
@@ -37,3 +37,14 @@ subCategories: [ "비트 및 바이트" ]
 
 --
 // OVERVIEW SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== See also
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Bits and Bytes/bitClear.adoc
+++ b/Language/Functions/Bits and Bytes/bitClear.adoc
@@ -38,3 +38,14 @@ subCategories: [ "비트 및 바이트" ]
 
 --
 // OVERVIEW SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== See also
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Bits and Bytes/bitRead.adoc
+++ b/Language/Functions/Bits and Bytes/bitRead.adoc
@@ -39,3 +39,14 @@ subCategories: [ "비트 및 바이트" ]
 
 --
 // OVERVIEW SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== See also
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Bits and Bytes/bitSet.adoc
+++ b/Language/Functions/Bits and Bytes/bitSet.adoc
@@ -38,3 +38,14 @@ subCategories: [ "비트 및 바이트" ]
 
 --
 // OVERVIEW SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== See also
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Bits and Bytes/bitWrite.adoc
+++ b/Language/Functions/Bits and Bytes/bitWrite.adoc
@@ -41,3 +41,14 @@ subCategories: [ "비트 및 바이트" ]
 
 --
 // OVERVIEW SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== See also
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/External Interrupts/attachInterrupt.adoc
+++ b/Language/Functions/External Interrupts/attachInterrupt.adoc
@@ -134,3 +134,14 @@ For Uno WiFiRev.2, Due, Zero, MKR Family and 101 boards the *interrupt number = 
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== See also
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/External Interrupts/detachInterrupt.adoc
+++ b/Language/Functions/External Interrupts/detachInterrupt.adoc
@@ -40,3 +40,14 @@ subCategories: [ "외부 인터럽트" ]
 
 --
 // OVERVIEW SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== See also
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Interrupts/noInterrupts.adoc
+++ b/Language/Functions/Interrupts/noInterrupts.adoc
@@ -65,3 +65,14 @@ void loop()
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== See also
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Math/abs.adoc
+++ b/Language/Functions/Math/abs.adoc
@@ -63,3 +63,14 @@ a++;        // 함수 밖에서 다른 수학
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== See also
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Math/constrain.adoc
+++ b/Language/Functions/Math/constrain.adoc
@@ -61,3 +61,14 @@ sensVal = constrain(sensVal, 10, 150);    // 센서 값을 10에서 150 사이�
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== See also
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Math/map.adoc
+++ b/Language/Functions/Math/map.adoc
@@ -101,3 +101,14 @@ long map(long x, long in_min, long in_max, long out_min, long out_max)
  As previously mentioned, the map() function uses integer math. So fractions might get suppressed due to this. For example, fractions like 3/2, 4/3, 5/4 will all be returned as 1 from the map() function, despite their different actual values. So if your project requires precise calculations (e.g. voltage accurate to 3 decimal places), please consider avoiding map() and implementing the calculations manually in your code yourself.
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== See also
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Math/max.adoc
+++ b/Language/Functions/Math/max.adoc
@@ -75,3 +75,14 @@ a--;     // 함수 밖 수학 지킴
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== See also
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Math/min.adoc
+++ b/Language/Functions/Math/min.adoc
@@ -76,3 +76,14 @@ a++;    // 대신 이렇게 쓰세요 - 함수 밖의 다른 수학 지킴
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== See also
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Math/sq.adoc
+++ b/Language/Functions/Math/sq.adoc
@@ -37,3 +37,14 @@ subCategories: [ "수학" ]
 
 --
 // OVERVIEW SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== See also
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Math/sqrt.adoc
+++ b/Language/Functions/Math/sqrt.adoc
@@ -37,3 +37,14 @@ subCategories: [ "수학" ]
 
 --
 // OVERVIEW SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== See also
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Random Numbers/random.adoc
+++ b/Language/Functions/Random Numbers/random.adoc
@@ -93,3 +93,14 @@ The `max` parameter should be chosen according to the data type of the variable 
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== See also
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Random Numbers/randomSeed.adoc
+++ b/Language/Functions/Random Numbers/randomSeed.adoc
@@ -71,3 +71,14 @@ void loop(){
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== See also
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Time/delayMicroseconds.adoc
+++ b/Language/Functions/Time/delayMicroseconds.adoc
@@ -76,3 +76,14 @@ void loop()
 아두이노 0018 현재, delayMicroseconds() 는 더이상 인터럽트를 비활성화 하지 않는다.
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== See also
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Functions/Time/micros.adoc
+++ b/Language/Functions/Time/micros.adoc
@@ -72,3 +72,14 @@ void loop(){
 1 밀리초는 1천 초, 1초는 1백만 초.
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== See also
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Structure/Sketch/loop.adoc
+++ b/Language/Structure/Sketch/loop.adoc
@@ -56,3 +56,14 @@ void loop()
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== See also
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Structure/Sketch/setup.adoc
+++ b/Language/Structure/Sketch/setup.adoc
@@ -50,3 +50,14 @@ void loop()
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== See also
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/word.adoc
+++ b/Language/Variables/Data Types/word.adoc
@@ -43,3 +43,14 @@ word는 16비트 부호없는 숫자, 0에서 65535까지를 저장한다. unsig
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== See also
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Variables/Utilities/sizeof.adoc
+++ b/Language/Variables/Utilities/sizeof.adoc
@@ -76,3 +76,14 @@ for (i = 0; i < (sizeof(myInts)/sizeof(myInts[0])); i++) {
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== See also
+
+--
+// SEE ALSO SECTION ENDS

--- a/Language/Variables/Variable Scope & Qualifiers/scope.adoc
+++ b/Language/Variables/Variable Scope & Qualifiers/scope.adoc
@@ -70,3 +70,14 @@ void loop()
 
 --
 // HOW TO USE SECTION ENDS
+
+
+// SEE ALSO SECTION
+[#see_also]
+--
+
+[float]
+=== See also
+
+--
+// SEE ALSO SECTION ENDS


### PR DESCRIPTION
When the "See also" section is missing, the automatically generated links to the other pages within the same subsection are added to a section titled "undefined".

Fixes https://github.com/arduino/reference-ko/issues/155