### PR TITLE
Always use capital s when referring to String objects

### DIFF
--- a/Language/Functions/Communication/Serial/readString.adoc
+++ b/Language/Functions/Communication/Serial/readString.adoc
@@ -14,7 +14,7 @@ title: Serial.readString()
 
 [float]
 === 설명
-`Serial.readString()` reads characters from the serial buffer into a string. The function terminates if it times out (see link:../settimeout[setTimeout()]).
+`Serial.readString()` reads characters from the serial buffer into a String. The function terminates if it times out (see link:../settimeout[setTimeout()]).
 
 This function is part of the Stream class, and is called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[Stream class] main page for more information.
 

--- a/Language/Functions/Communication/Serial/readStringUntil.adoc
+++ b/Language/Functions/Communication/Serial/readStringUntil.adoc
@@ -14,7 +14,7 @@ title: Serial.readStringUntil()
 
 [float]
 === 설명
-`readStringUntil()` reads characters from the serial buffer into a string. The function terminates if it times out (see link:../settimeout[setTimeout()]).
+`readStringUntil()` reads characters from the serial buffer into a String. The function terminates if it times out (see link:../settimeout[setTimeout()]).
 
 This function is part of the Stream class, and is called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[Stream class] main page for more information.
 

--- a/Language/Variables/Data Types/String/Functions/c_str.adoc
+++ b/Language/Variables/Data Types/String/Functions/c_str.adoc
@@ -24,10 +24,7 @@ subCategories: [ "스트링개체 함수" ]
 
 [float]
 === 문법
-[source,arduino]
-----
-string.c_str()
-----
+`myString.c_str()`
 
 [float]
 === 매개변수

--- a/Language/Variables/Data Types/String/Functions/charAt.adoc
+++ b/Language/Variables/Data Types/String/Functions/charAt.adoc
@@ -24,14 +24,11 @@ subCategories: [ "스트링개체 함수" ]
 
 [float]
 === 문법
-[source,arduino]
-----
-string.charAt(n)
-----
+`myString.charAt(n)`
 
 [float]
 === 매개변수
-`string`: string 형 변수
+`myString`: string 형 변수
 
 `n`: unsigned int 형 변수
 

--- a/Language/Variables/Data Types/String/Functions/compareTo.adoc
+++ b/Language/Variables/Data Types/String/Functions/compareTo.adoc
@@ -25,25 +25,22 @@ subCategories: [ "스트링개체 함수" ]
 
 [float]
 === 문법
-[source,arduino]
-----
-string.compareTo(string2)
-----
+`myString.compareTo(myString2)`
 
 [float]
 === 매개변수
-`string`: 스트링 형 변수
+`myString`: 스트링 형 변수
 
-`string2`: 스트링 형 다른 변수
+`myString2`: 스트링 형 다른 변수
 
 
 [float]
 === 반환
-`음수`: string 이 string2 앞에
+`음수`: myString 이 myString2 앞에
 
-`0`: string 이 string2 와 같음
+`0`: myString 이 myString2 와 같음
 
-`양수`: string 이 string2 뒤에
+`양수`: myString 이 myString2 뒤에
 --
 
 // OVERVIEW SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/concat.adoc
+++ b/Language/Variables/Data Types/String/Functions/concat.adoc
@@ -23,10 +23,7 @@ subCategories: [ "스트링개체 함수" ]
 
 [float]
 === 문법
-[source,arduino]
-----
-string.concat(parameter)
-----
+`myString.concat(parameter)`
 
 [float]
 === 매개변수

--- a/Language/Variables/Data Types/String/Functions/endsWith.adoc
+++ b/Language/Variables/Data Types/String/Functions/endsWith.adoc
@@ -24,21 +24,18 @@ subCategories: [ "스트링개체 함수" ]
 
 [float]
 === 문법
-[source,arduino]
-----
-string.endsWith(string2)
-----
+`myString.endsWith(myString2)`
 
 [float]
 === 매개변수
-`string`: 스트링 형 변수
+`myString`: 스트링 형 변수
 
-`string2`: 또다른 스트링 형 변수
+`myString2`: 또다른 스트링 형 변수
 
 
 [float]
 === 반환
-`true`: string 이 string2의 문자들로 끝날 때
+`true`: myString 이 myString2의 문자들로 끝날 때
 
 `false`: 아니면
 

--- a/Language/Variables/Data Types/String/Functions/equals.adoc
+++ b/Language/Variables/Data Types/String/Functions/equals.adoc
@@ -23,19 +23,16 @@ subCategories: [ "스트링개체 함수" ]
 
 [float]
 === 문법
-[source,arduino]
-----
-string.equals(string2)
-----
+`myString.equals(myString2)`
 
 [float]
 === 매개변수
-`string, string2`: 스트링 형 변수
+`myString, myString2`: 스트링 형 변수
 
 
 [float]
 === 반환
-`true`: string 이 string2 와 같으면
+`true`: myString 이 myString2 와 같으면
 
 `false`: 아니면
 --

--- a/Language/Variables/Data Types/String/Functions/equalsIgnoreCase.adoc
+++ b/Language/Variables/Data Types/String/Functions/equalsIgnoreCase.adoc
@@ -23,19 +23,16 @@ subCategories: [ "스트링개체 함수" ]
 
 [float]
 === 문법
-[source,arduino]
-----
-string.equalsIgnoreCase(string2)
-----
+`myString.equalsIgnoreCase(myString2)`
 
 [float]
 === 매개변수
-`string, string2`: 스트링 형 변수
+`myString, myString2`: 스트링 형 변수
 
 
 [float]
 === 반환
-`true`: string 과 string2 이 같으면(대소문자 무시)
+`true`: myString 과 myString2 이 같으면(대소문자 무시)
 
 `false`: 아니면
 --

--- a/Language/Variables/Data Types/String/Functions/getBytes.adoc
+++ b/Language/Variables/Data Types/String/Functions/getBytes.adoc
@@ -23,14 +23,11 @@ subCategories: [ "스트링개체 함수" ]
 
 [float]
 === 문법
-[source,arduino]
-----
-string.getBytes(buf, len)
-----
+`myString.getBytes(buf, len)`
 
 [float]
 === 매개변수
-`string`: 스트링 형 변수
+`myString`: 스트링 형 변수
 
 `buf`: 문자를 복사해 넣을 버퍼(_byte []_)
 

--- a/Language/Variables/Data Types/String/Functions/indexOf.adoc
+++ b/Language/Variables/Data Types/String/Functions/indexOf.adoc
@@ -25,16 +25,12 @@ subCategories: [ "스트링개체 함수" ]
 
 [float]
 === 문법
-[source,arduino]
-----
-string.indexOf(val)
-
-string.indexOf(val, from)
-----
+`myString.indexOf(val)` +
+`myString.indexOf(val, from)`
 
 [float]
 === 매개변수
-`string`: 스트링 형 변수
+`myString`: 스트링 형 변수
 
 `val`: 찾을 값 - char 또는 스트링
 

--- a/Language/Variables/Data Types/String/Functions/lastIndexOf.adoc
+++ b/Language/Variables/Data Types/String/Functions/lastIndexOf.adoc
@@ -23,16 +23,12 @@ subCategories: [ "스트링개체 함수" ]
 
 [float]
 === 문법
-[source,arduino]
-----
-string.lastIndexOf(val)
-
-string.lastIndexOf(val, from)
-----
+`myString.lastIndexOf(val)` +
+`myString.lastIndexOf(val, from)`
 
 [float]
 === 매개변수
-`string`: 스트링 형 변수
+`myString`: 스트링 형 변수
 
 `val`: 찾을 값 - char 또는 스트링
 

--- a/Language/Variables/Data Types/String/Functions/length.adoc
+++ b/Language/Variables/Data Types/String/Functions/length.adoc
@@ -23,14 +23,11 @@ subCategories: [ "스트링개체 함수" ]
 
 [float]
 === 문법
-[source,arduino]
-----
-string.length()
-----
+`myString.length()`
 
 [float]
 === 매개변수
-`string`: 스트링 형 변수
+`myString`: 스트링 형 변수
 
 
 [float]

--- a/Language/Variables/Data Types/String/Functions/remove.adoc
+++ b/Language/Variables/Data Types/String/Functions/remove.adoc
@@ -23,12 +23,8 @@ subCategories: [ "스트링개체 함수" ]
 
 [float]
 === 문법
-[source,arduino]
-----
-string.remove(index)
-
-string.remove(index, count)
-----
+`myString.remove(index)` +
+`myString.remove(index, count)`
 
 [float]
 === 매개변수

--- a/Language/Variables/Data Types/String/Functions/replace.adoc
+++ b/Language/Variables/Data Types/String/Functions/replace.adoc
@@ -23,14 +23,11 @@ subCategories: [ "스트링개체 함수" ]
 
 [float]
 === 문법
-[source,arduino]
-----
-string.replace(substring1, substring2)
-----
+`myString.replace(substring1, substring2)`
 
 [float]
 === 매개변수
-`string`: 스트링 형 변수
+`myString`: 스트링 형 변수
 
 `substring1`: 다른 스트링 형 변수
 

--- a/Language/Variables/Data Types/String/Functions/reserve.adoc
+++ b/Language/Variables/Data Types/String/Functions/reserve.adoc
@@ -23,10 +23,7 @@ subCategories: [ "스트링개체 함수" ]
 
 [float]
 === 문법
-[source,arduino]
-----
-string.reserve(size)
-----
+`myString.reserve(size)`
 
 [float]
 === 매개변수

--- a/Language/Variables/Data Types/String/Functions/setCharAt.adoc
+++ b/Language/Variables/Data Types/String/Functions/setCharAt.adoc
@@ -23,14 +23,11 @@ subCategories: [ "스트링개체 함수" ]
 
 [float]
 === 문법
-[source,arduino]
-----
-string.setCharAt(index, c)
-----
+`myString.setCharAt(index, c)`
 
 [float]
 === 매개변수
-`string`: 스트링 형 변수
+`myString`: 스트링 형 변수
 
 `index`: 문자를 설정한 위치의 인덱스
 

--- a/Language/Variables/Data Types/String/Functions/startsWith.adoc
+++ b/Language/Variables/Data Types/String/Functions/startsWith.adoc
@@ -24,19 +24,16 @@ subCategories: [ "스트링개체 함수" ]
 
 [float]
 === 문법
-[source,arduino]
-----
-string.startsWith(string2)
-----
+`myString.startsWith(myString2)`
 
 [float]
 === 매개변수
-`string, string2`: a variable of type String
+`myString, myString2`: a variable of type String
 
 
 [float]
 === 반환
-`true`: string 이 string2의 문자들로 시작하면
+`true`: myString 이 myString2의 문자들로 시작하면
 
 `false`: 아니면
 --

--- a/Language/Variables/Data Types/String/Functions/substring.adoc
+++ b/Language/Variables/Data Types/String/Functions/substring.adoc
@@ -26,16 +26,12 @@ If the ending index is omitted, the substring continues to the end of the String
 
 [float]
 === 문법
-[source,arduino]
-----
-string.substring(from)
-
-string.substring(from, to)
-----
+`myString.substring(from)` +
+`myString.substring(from, to)`
 
 [float]
 === 매개변수
-`string`: String 형 변수
+`myString`: String 형 변수
 
 `from`: 서브스트링이 시작하는 인덱스
 

--- a/Language/Variables/Data Types/String/Functions/toCharArray.adoc
+++ b/Language/Variables/Data Types/String/Functions/toCharArray.adoc
@@ -23,14 +23,11 @@ String의 문자를 제공되는 버퍼에 복사.
 
 [float]
 === 문법
-[source,arduino]
-----
-string.toCharArray(buf, len)
-----
+`myString.toCharArray(buf, len)`
 
 [float]
 === 매개변수
-`string`: 스트링 형 변수
+`myString`: 스트링 형 변수
 
 `buf`: 문자를 복사해 넣을 버퍼 (_char []_)
 

--- a/Language/Variables/Data Types/String/Functions/toFloat.adoc
+++ b/Language/Variables/Data Types/String/Functions/toFloat.adoc
@@ -25,14 +25,11 @@ The input String should start with a digit. If the String contains non-digit cha
 
 [float]
 === 문법
-[source,arduino]
-----
-string.toFloat()
-----
+`myString.toFloat()`
 
 [float]
 === 매개변수
-`string`: a variable of type String
+`myString`: a variable of type String
 
 
 [float]

--- a/Language/Variables/Data Types/String/Functions/toInt.adoc
+++ b/Language/Variables/Data Types/String/Functions/toInt.adoc
@@ -23,14 +23,11 @@ subCategories: [ "스트링개체 함수" ]
 
 [float]
 === 문법
-[source,arduino]
-----
-string.toInt()
-----
+`myString.toInt()`
 
 [float]
 === 매개변수
-`string`: 스트링 형 변수
+`myString`: 스트링 형 변수
 
 
 [float]

--- a/Language/Variables/Data Types/String/Functions/toLowerCase.adoc
+++ b/Language/Variables/Data Types/String/Functions/toLowerCase.adoc
@@ -23,14 +23,11 @@ subCategories: [ "스트링개체 함수" ]
 
 [float]
 === 문법
-[source,arduino]
-----
-string.toLowerCase()
-----
+`myString.toLowerCase()`
 
 [float]
 === 매개변수
-`string`: 스트링 형 변수
+`myString`: 스트링 형 변수
 
 
 [float]

--- a/Language/Variables/Data Types/String/Functions/toUpperCase.adoc
+++ b/Language/Variables/Data Types/String/Functions/toUpperCase.adoc
@@ -23,14 +23,11 @@ subCategories: [ "스트링개체 함수" ]
 
 [float]
 === 문법
-[source,arduino]
-----
-string.toUpperCase()
-----
+`myString.toUpperCase()`
 
 [float]
 === 매개변수
-`string`: 스트링 형 변수
+`myString`: 스트링 형 변수
 
 
 [float]

--- a/Language/Variables/Data Types/String/Functions/trim.adoc
+++ b/Language/Variables/Data Types/String/Functions/trim.adoc
@@ -23,14 +23,11 @@ subCategories: [ "스트링개체 함수" ]
 
 [float]
 === 문법
-[source,arduino]
-----
-string.trim()
-----
+`myString.trim()`
 
 [float]
 === 매개변수
-`string`: 스트링 형 변수
+`myString`: 스트링 형 변수
 
 
 [float]

--- a/Language/Variables/Data Types/String/Operators/append.adoc
+++ b/Language/Variables/Data Types/String/Operators/append.adoc
@@ -27,12 +27,13 @@ subCategories: [ "스트링개체 연산자" ]
 === 문법
 [source,arduino]
 ----
-string += data
+myString1 += data
 ----
 
 [float]
 === 매개변수
-없음
+`myString1` - String 변수
+
 
 [float]
 === 반환

--- a/Language/Variables/Data Types/String/Operators/comparison.adoc
+++ b/Language/Variables/Data Types/String/Operators/comparison.adoc
@@ -29,18 +29,18 @@ subCategories: [ "스트링개체 연산자" ]
 === 문법
 [source,arduino]
 ----
-string1 == string2
+myString1 == myString2
 ----
 
 [float]
 === 매개변수
-`string1, string2` - String 변수
+`myString1, myString2` - String 변수
 
 [float]
 === 반환
 스트링의 n 번째 문자. charAt() 과 같다.
 
-`true`: string1 이 string2 와 같으면
+`true`: myString1 이 myString2 와 같으면
 
 `false`: 아니면
 --

--- a/Language/Variables/Data Types/String/Operators/concatenation.adoc
+++ b/Language/Variables/Data Types/String/Operators/concatenation.adoc
@@ -27,12 +27,12 @@ subCategories: [ "스트링개체 연산자" ]
 === 문법
 [source,arduino]
 ----
-string3 = string1 + string 2; string3 += string2;
+myString3 = myString1 + myString2
 ----
 
 [float]
 === 매개변수
-`string, string1, string2, string3` - a string variable
+`myString1, myString2, myString3` - a String variable
 
 [float]
 === 반환

--- a/Language/Variables/Data Types/String/Operators/differentFrom.adoc
+++ b/Language/Variables/Data Types/String/Operators/differentFrom.adoc
@@ -26,16 +26,16 @@ subCategories: [ "스트링개체 연산자" ]
 === 문법
 [source,arduino]
 ----
-string1 != string2
+myString1 != myString2
 ----
 
 [float]
 === 매개변수
-`string1, string2` - String 변수
+`myString1, myString2` - String 변수
 
 [float]
 === 반환
-`true`: string1 이 string2 와 다르면
+`true`: myString1 이 myString2 와 다르면
 
 `false`: 아니면
 

--- a/Language/Variables/Data Types/String/Operators/elementAccess.adoc
+++ b/Language/Variables/Data Types/String/Operators/elementAccess.adoc
@@ -27,14 +27,14 @@ String의 개별 문자에 접근하는 것을 허용.
 === 문법
 [source,arduino]
 ----
-char thisChar = string1[n]
+char thisChar = myString1[n]
 ----
 
 [float]
 === 매개변수
 `char thisChar` - 문자 변수
 
-`string1` - String 변수
+`myString1` - String 변수
 
 `int n` - 숫자 변수
 

--- a/Language/Variables/Data Types/String/Operators/greaterThan.adoc
+++ b/Language/Variables/Data Types/String/Operators/greaterThan.adoc
@@ -33,16 +33,16 @@ subCategories: [ "스트링개체 연산자" ]
 === 문법
 [source,arduino]
 ----
-string1 > string2
+myString1 > myString2
 ----
 
 [float]
 === 매개변수
-`string1, string2` - String 변수
+`myString1, myString2` - String 변수
 
 [float]
 === 반환
-`true`: string1 이 string2 보다 크면
+`true`: myString1 이 myString2 보다 크면
 
 `false`: 아니면
 

--- a/Language/Variables/Data Types/String/Operators/greaterThanOrEqualTo.adoc
+++ b/Language/Variables/Data Types/String/Operators/greaterThanOrEqualTo.adoc
@@ -32,17 +32,17 @@ subCategories: [ "스트링개체 연산자" ]
 === 문법
 [source,arduino]
 ----
-string1 >= string2
+myString1 >= myString2
 ----
 
 [float]
 === 매개변수
-`string1, string2`: variables of type String
+`myString1, myString2`: variables of type String
 
 
 [float]
 === 반환
-`true`: string1 이 string2 보다 크거나 같으면
+`true`: myString1 이 myString2 보다 크거나 같으면
 
 `false`: 아니면
 --

--- a/Language/Variables/Data Types/String/Operators/lessThan.adoc
+++ b/Language/Variables/Data Types/String/Operators/lessThan.adoc
@@ -31,16 +31,16 @@ subCategories: [ "스트링개체 연산자" ]
 === 문법
 [source,arduino]
 ----
-string1 < string2
+myString1 < myString2
 ----
 
 [float]
 === 매개변수
-`string1, string2`: variables of type String
+`myString1, myString2`: variables of type String
 
 [float]
 === 반환
-`true`: 만약 string1 이 string2 보다 크면
+`true`: 만약 myString1 이 myString2 보다 크면
 
 `false`: 아니면
 --

--- a/Language/Variables/Data Types/String/Operators/lessThanOrEqualTo.adoc
+++ b/Language/Variables/Data Types/String/Operators/lessThanOrEqualTo.adoc
@@ -31,16 +31,16 @@ subCategories: [ "스트링개체 연산자" ]
 === 문법
 [source,arduino]
 ----
-string1 <= string2
+myString1 <= myString2
 ----
 
 [float]
 === 매개변수
-`string1, string2`: variables of type String
+`myString1, myString2`: variables of type String
 
 [float]
 === 반환
-`true`: string1 이 string2 보다 작거나 같으면
+`true`: myString1 이 myString2 보다 작거나 같으면
 
 `false`: 아니면
 


### PR DESCRIPTION
Beginners are frequently confused about String vs strings so it's important to make a clear distinction between the two in the documentation.

Fixes https://github.com/arduino/reference-ko/issues/158