### PR TITLE
Add comment to goto example code to indicate that a label must be followed by a statement

### DIFF
--- a/Language/Structure/Control Structure/goto.adoc
+++ b/Language/Structure/Control Structure/goto.adoc
@@ -55,6 +55,7 @@ for(byte r = 0; r < 255; r++){
 }
 
 bailout:
+// more statements ...
 ----
 [%hardbreaks]
 


### PR DESCRIPTION
A label that is not followed by a statement results in a somewhat confusing compilation error. It is hoped that a simple comment in the example code will steer people in the right direction without requiring an increase in the complexity of the description or notes for goto.

Fixes https://github.com/arduino/reference-ko/issues/162