### PR TITLE
Remove empty "Notes and Warnings" section from Serial.findUntil()

### DIFF
--- a/Language/Functions/Communication/Serial/findUntil.adoc
+++ b/Language/Functions/Communication/Serial/findUntil.adoc
@@ -40,19 +40,6 @@ The function returns true if the target string is found, false if it times out.
 // OVERVIEW SECTION ENDS
 
 
-
-
-// HOW TO USE SECTION STARTS
-[#howtouse]
---
-
-[float]
-=== 주의와 경고
-
---
-// HOW TO USE SECTION ENDS
-
-
 // SEE ALSO SECTION
 [#see_also]
 --


### PR DESCRIPTION
Fixes https://github.com/arduino/reference-ko/issues/163