### PR TITLE
Fix formatting of example links

### DIFF
--- a/Language/Variables/Data Types/String/Functions/c_str.adoc
+++ b/Language/Variables/Data Types/String/Functions/c_str.adoc
@@ -49,6 +49,6 @@ none
 === 더보기
 
 [role="example"]
-* #EXAMPLE# link: https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/charAt.adoc
+++ b/Language/Variables/Data Types/String/Functions/charAt.adoc
@@ -54,6 +54,6 @@ subCategories: [ "스트링개체 함수" ]
 === 더보기
 
 [role="example"]
-* #EXAMPLE# link: https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/compareTo.adoc
+++ b/Language/Variables/Data Types/String/Functions/compareTo.adoc
@@ -58,6 +58,6 @@ subCategories: [ "스트링개체 함수" ]
 === 더보기
 
 [role="example"]
-* #EXAMPLE# link: https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/concat.adoc
+++ b/Language/Variables/Data Types/String/Functions/concat.adoc
@@ -51,6 +51,6 @@ subCategories: [ "스트링개체 함수" ]
 === 더보기
 
 [role="example"]
-* #EXAMPLE# link: https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/endsWith.adoc
+++ b/Language/Variables/Data Types/String/Functions/endsWith.adoc
@@ -55,6 +55,6 @@ subCategories: [ "스트링개체 함수" ]
 === 더보기
 
 [role="example"]
-* #EXAMPLE# link: https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/equals.adoc
+++ b/Language/Variables/Data Types/String/Functions/equals.adoc
@@ -51,6 +51,6 @@ subCategories: [ "스트링개체 함수" ]
 === 더보기
 
 [role="example"]
-* #EXAMPLE# link: https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/equalsIgnoreCase.adoc
+++ b/Language/Variables/Data Types/String/Functions/equalsIgnoreCase.adoc
@@ -51,6 +51,6 @@ subCategories: [ "스트링개체 함수" ]
 === 더보기
 
 [role="example"]
-* #EXAMPLE# link: https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/getBytes.adoc
+++ b/Language/Variables/Data Types/String/Functions/getBytes.adoc
@@ -53,6 +53,6 @@ subCategories: [ "스트링개체 함수" ]
 === 더보기
 
 [role="example"]
-* #EXAMPLE# link: https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/indexOf.adoc
+++ b/Language/Variables/Data Types/String/Functions/indexOf.adoc
@@ -56,6 +56,6 @@ subCategories: [ "스트링개체 함수" ]
 === 더보기
 
 [role="example"]
-* #EXAMPLE# link: https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/lastIndexOf.adoc
+++ b/Language/Variables/Data Types/String/Functions/lastIndexOf.adoc
@@ -56,6 +56,6 @@ subCategories: [ "스트링개체 함수" ]
 === 더보기
 
 [role="example"]
-* #EXAMPLE# link: https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/length.adoc
+++ b/Language/Variables/Data Types/String/Functions/length.adoc
@@ -50,6 +50,6 @@ subCategories: [ "스트링개체 함수" ]
 === 더보기
 
 [role="example"]
-* #EXAMPLE# link: https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/remove.adoc
+++ b/Language/Variables/Data Types/String/Functions/remove.adoc
@@ -53,6 +53,6 @@ subCategories: [ "스트링개체 함수" ]
 === 더보기
 
 [role="example"]
-* #EXAMPLE# link: https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/replace.adoc
+++ b/Language/Variables/Data Types/String/Functions/replace.adoc
@@ -54,6 +54,6 @@ subCategories: [ "스트링개체 함수" ]
 === 더보기
 
 [role="example"]
-* #EXAMPLE# link: https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/reserve.adoc
+++ b/Language/Variables/Data Types/String/Functions/reserve.adoc
@@ -80,6 +80,6 @@ void loop() {
 === 더보기
 
 [role="example"]
-* #EXAMPLE# link: https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/setCharAt.adoc
+++ b/Language/Variables/Data Types/String/Functions/setCharAt.adoc
@@ -54,6 +54,6 @@ subCategories: [ "스트링개체 함수" ]
 === 더보기
 
 [role="example"]
-* #EXAMPLE# link: https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/startsWith.adoc
+++ b/Language/Variables/Data Types/String/Functions/startsWith.adoc
@@ -52,6 +52,6 @@ subCategories: [ "스트링개체 함수" ]
 === 더보기
 
 [role="example"]
-* #EXAMPLE# link: https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/substring.adoc
+++ b/Language/Variables/Data Types/String/Functions/substring.adoc
@@ -58,6 +58,6 @@ If the ending index is omitted, the substring continues to the end of the String
 === 더보기
 
 [role="example"]
-* #EXAMPLE# link: https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/toCharArray.adoc
+++ b/Language/Variables/Data Types/String/Functions/toCharArray.adoc
@@ -53,6 +53,6 @@ String의 문자를 제공되는 버퍼에 복사.
 === 더보기
 
 [role="example"]
-* #EXAMPLE# link: https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/toFloat.adoc
+++ b/Language/Variables/Data Types/String/Functions/toFloat.adoc
@@ -54,6 +54,6 @@ The input String should start with a digit. If the String contains non-digit cha
 === 더보기
 
 [role="example"]
-* #EXAMPLE# link: https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/toInt.adoc
+++ b/Language/Variables/Data Types/String/Functions/toInt.adoc
@@ -51,6 +51,6 @@ subCategories: [ "스트링개체 함수" ]
 === 더보기
 
 [role="example"]
-* #EXAMPLE# link: https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/toLowerCase.adoc
+++ b/Language/Variables/Data Types/String/Functions/toLowerCase.adoc
@@ -50,6 +50,6 @@ subCategories: [ "스트링개체 함수" ]
 === 더보기
 
 [role="example"]
-* #EXAMPLE# link: https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/toUpperCase.adoc
+++ b/Language/Variables/Data Types/String/Functions/toUpperCase.adoc
@@ -50,6 +50,6 @@ subCategories: [ "스트링개체 함수" ]
 === 더보기
 
 [role="example"]
-* #EXAMPLE# link: https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Functions/trim.adoc
+++ b/Language/Variables/Data Types/String/Functions/trim.adoc
@@ -50,6 +50,6 @@ subCategories: [ "스트링개체 함수" ]
 === 더보기
 
 [role="example"]
-* #EXAMPLE# link: https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Operators/append.adoc
+++ b/Language/Variables/Data Types/String/Operators/append.adoc
@@ -56,6 +56,6 @@ myString1 += data
 === 더보기
 
 [role="example"]
-* #EXAMPLE# link: https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Operators/comparison.adoc
+++ b/Language/Variables/Data Types/String/Operators/comparison.adoc
@@ -60,6 +60,6 @@ myString1 == myString2
 === 더보기
 
 [role="example"]
-* #EXAMPLE# link: https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Operators/concatenation.adoc
+++ b/Language/Variables/Data Types/String/Operators/concatenation.adoc
@@ -56,6 +56,6 @@ new String that is the combination of the original two Strings.
 === 더보기
 
 [role="example"]
-* #EXAMPLE# link: https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Operators/differentFrom.adoc
+++ b/Language/Variables/Data Types/String/Operators/differentFrom.adoc
@@ -56,6 +56,6 @@ myString1 != myString2
 === 더보기
 
 [role="example"]
-* #EXAMPLE# link: https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Operators/elementAccess.adoc
+++ b/Language/Variables/Data Types/String/Operators/elementAccess.adoc
@@ -60,6 +60,6 @@ String의  n번째 char. Same as charAt().
 === 더보기
 
 [role="example"]
-* #EXAMPLE# link: https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Operators/greaterThan.adoc
+++ b/Language/Variables/Data Types/String/Operators/greaterThan.adoc
@@ -63,6 +63,6 @@ myString1 > myString2
 === 더보기
 
 [role="example"]
-* #EXAMPLE# link: https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Operators/greaterThanOrEqualTo.adoc
+++ b/Language/Variables/Data Types/String/Operators/greaterThanOrEqualTo.adoc
@@ -62,6 +62,6 @@ myString1 >= myString2
 === 더보기
 
 [role="example"]
-* #EXAMPLE# link: https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Operators/lessThan.adoc
+++ b/Language/Variables/Data Types/String/Operators/lessThan.adoc
@@ -60,6 +60,6 @@ myString1 < myString2
 === 더보기
 
 [role="example"]
-* #EXAMPLE# link: https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/String/Operators/lessThanOrEqualTo.adoc
+++ b/Language/Variables/Data Types/String/Operators/lessThanOrEqualTo.adoc
@@ -61,6 +61,6 @@ myString1 <= myString2
 === 더보기
 
 [role="example"]
-* #EXAMPLE# link: https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Variables/Data Types/stringObject.adoc
+++ b/Language/Variables/Data Types/stringObject.adoc
@@ -144,7 +144,7 @@ String stringOne =  String(5.698, 3);                 // using a float and the d
 * #LANGUAGE# link:../string/operators/differentfrom[!= (different from)]
 
 [role="example"]
-* #EXAMPLE# link: https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
+* #EXAMPLE# https://www.arduino.cc/en/Tutorial/BuiltInExamples#strings[Built-in String Tutorials^]
 
 
 // SEE ALSO SECTION STARTS


### PR DESCRIPTION
The space between link: and the URL caused the "link:" to be shown as text on the page. Since all the other example links do not use the link: markup, I removed it from the incorrectly formatted links.

Fixes https://github.com/arduino/reference-ko/issues/166