### PR TITLE
Remove unnecessary "See Also" link

### DIFF
--- a/Language/Variables/Data Types/boolean.adoc
+++ b/Language/Variables/Data Types/boolean.adoc
@@ -76,7 +76,6 @@ void loop()
 === 더보기
 
 [role="language"]
-* #LANGUAGE# link:../../../variables/constants/constants[constants]
 
 --
 // SEE ALSO SECTION ENDS


### PR DESCRIPTION
"See Also" links for all pages in the same section are automatically added so this link only makes the reference more difficult to maintain.

Fixes https://github.com/arduino/reference-ko/issues/167