### PR TITLE
Remove empty "Example Code" sections

### DIFF
--- a/Language/Functions/Communication/Stream/streamPeek.adoc
+++ b/Language/Functions/Communication/Stream/streamPeek.adoc
@@ -43,9 +43,6 @@ The next byte (or character), or -1 if none is available.
 [#howtouse]
 --
 
-[float]
-=== 예제 코드
-// Describe what the example code is all about and add relevant code   ►►►►► THIS SECTION IS MANDATORY ◄◄◄◄◄
 
 --
 // HOW TO USE SECTION ENDS

--- a/Language/Variables/Data Types/byte.adoc
+++ b/Language/Variables/Data Types/byte.adoc
@@ -30,15 +30,6 @@ byte 는 8비트 부호없는 숫자, 0부터 255까지를 저장한다.
 [#howtouse]
 --
 
-[float]
-=== 예제 코드
-// Describe what the example code is all about and add relevant code
-
-
-[source,arduino]
-----
-
-----
 
 --
 // HOW TO USE SECTION ENDS


### PR DESCRIPTION
Fixes https://github.com/arduino/reference-ko/issues/169