### PR TITLE
Correct title of serialEvent() reference page

### DIFF
--- a/Language/Functions/Communication/Serial/serialEvent.adoc
+++ b/Language/Functions/Communication/Serial/serialEvent.adoc
@@ -1,5 +1,5 @@
 ---
-title: Serial.serialEvent()
+title: serialEvent()
 ---
 
 


### PR DESCRIPTION
There is no such thing as Serial.serialEvent() so the previous title was incorrect.

Fixes https://github.com/arduino/reference-ko/issues/182