### PR TITLE
Don't use reserved name as a variable name in the example code

### DIFF
--- a/Language/Functions/Characters/isAlpha.adoc
+++ b/Language/Functions/Characters/isAlpha.adoc
@@ -50,7 +50,7 @@ isAlpha(thisChar)
 
 [source,arduino]
 ----
-if (isAlpha(this))      // this가 알파벳인지 테스트
+if (isAlpha(myChar))      // myChar가 알파벳인지 테스트
 {
 	Serial.println("The character is a letter");
 }

--- a/Language/Functions/Characters/isAlphaNumeric.adoc
+++ b/Language/Functions/Characters/isAlphaNumeric.adoc
@@ -50,7 +50,7 @@ subCategories: [ "문자" ]
 
 [source,arduino]
 ----
-if (isAlphaNumeric(this))      // this가 문자 혹은 숫자인지 테스트
+if (isAlphaNumeric(myChar))      // myChar가 문자 혹은 숫자인지 테스트
 {
 	Serial.println("The character is alphanumeric");
 }

--- a/Language/Functions/Characters/isAscii.adoc
+++ b/Language/Functions/Characters/isAscii.adoc
@@ -50,7 +50,7 @@ isAscii(thisChar)
 
 [source,arduino]
 ----
-if (isAscii(this))      // this가 아스키 문자인지 테스트
+if (isAscii(myChar))      // myChar가 아스키 문자인지 테스트
 {
 	Serial.println("The character is Ascii");
 }

--- a/Language/Functions/Characters/isControl.adoc
+++ b/Language/Functions/Characters/isControl.adoc
@@ -50,7 +50,7 @@ isControl(thisChar)
 
 [source,arduino]
 ----
-if (isControl(this))      // tests if this is a control character
+if (isControl(myChar))      // tests if myChar is a control character
 {
 	Serial.println("The character is a control character");
 }

--- a/Language/Functions/Characters/isDigit.adoc
+++ b/Language/Functions/Characters/isDigit.adoc
@@ -50,7 +50,7 @@ isDigit(thisChar)
 
 [source,arduino]
 ----
-if (isDigit(this))      // tests if this is a digit
+if (isDigit(myChar))      // tests if myChar is a digit
 {
 	Serial.println("The character is a number");
 }

--- a/Language/Functions/Characters/isGraph.adoc
+++ b/Language/Functions/Characters/isGraph.adoc
@@ -50,7 +50,7 @@ isGraph(thisChar)
 
 [source,arduino]
 ----
-if (isGraph(this))      // tests if this is a printable character but not a blank space.
+if (isGraph(myChar))      // tests if myChar is a printable character but not a blank space.
 {
 	Serial.println("The character is printable");
 }

--- a/Language/Functions/Characters/isHexadecimalDigit.adoc
+++ b/Language/Functions/Characters/isHexadecimalDigit.adoc
@@ -50,7 +50,7 @@ isHexadecimalDigit(thisChar)
 
 [source,arduino]
 ----
-if (isHexadecimalDigit(this))      // tests if this is an hexadecimal digit
+if (isHexadecimalDigit(myChar))      // tests if myChar is an hexadecimal digit
 {
 	Serial.println("The character is an hexadecimal digit");
 }

--- a/Language/Functions/Characters/isLowerCase.adoc
+++ b/Language/Functions/Characters/isLowerCase.adoc
@@ -50,7 +50,7 @@ isLowerCase(thisChar)
 
 [source,arduino]
 ----
-if (isLowerCase(this))      // tests if this is a lower case letter
+if (isLowerCase(myChar))      // tests if myChar is a lower case letter
 {
 	Serial.println("The character is lower case");
 }

--- a/Language/Functions/Characters/isPrintable.adoc
+++ b/Language/Functions/Characters/isPrintable.adoc
@@ -50,7 +50,7 @@ isPrintable(thisChar)
 
 [source,arduino]
 ----
-if (isPrintable(this))      // 출력 가능한 문자인지 테스트.
+if (isPrintable(myChar))      // 출력 가능한 문자인지 테스트.
 {
 	Serial.println("The character is printable");
 }

--- a/Language/Functions/Characters/isPunct.adoc
+++ b/Language/Functions/Characters/isPunct.adoc
@@ -50,7 +50,7 @@ isPunct(thisChar)
 
 [source,arduino]
 ----
-if (isPunct(this))      // tests if this is a punctuation character
+if (isPunct(myChar))      // tests if myChar is a punctuation character
 {
 	Serial.println("The character is a punctuation");
 }

--- a/Language/Functions/Characters/isSpace.adoc
+++ b/Language/Functions/Characters/isSpace.adoc
@@ -50,7 +50,7 @@ isSpace(thisChar)
 
 [source,arduino]
 ----
-if (isSpace(this))      // tests if this is the space character
+if (isSpace(myChar))      // tests if myChar is the space character
 {
 	Serial.println("The character is a space");
 }

--- a/Language/Functions/Characters/isUpperCase.adoc
+++ b/Language/Functions/Characters/isUpperCase.adoc
@@ -50,7 +50,7 @@ isUpperCase(thisChar)
 
 [source,arduino]
 ----
-if (isUpperCase(this))      // tests if this is an upeer case letter
+if (isUpperCase(myChar))      // tests if myChar is an upeer case letter
 {
 	Serial.println("The character is upper case");
 }

--- a/Language/Functions/Characters/isWhitespace.adoc
+++ b/Language/Functions/Characters/isWhitespace.adoc
@@ -49,7 +49,7 @@ thisChar가 공백 문자이면 true를 반환합니다.
 
 [source,arduino]
 ----
-if (isWhitespace(this))      // tests if this is a white space
+if (isWhitespace(myChar))      // tests if myChar is a white space
 {
 	Serial.println("The character is a white space");
 }


### PR DESCRIPTION
this is a reserved name and may not be used as a variable name. Attempts to do so result in a somewhat confusing compilation error.

Fixes https://github.com/arduino/reference-ko/issues/213