### PR TITLE
Remove incomplete list of baud rates

### DIFF
--- a/Language/Functions/Communication/Serial/begin.adoc
+++ b/Language/Functions/Communication/Serial/begin.adoc
@@ -14,7 +14,7 @@ title: Serial.begin()
 
 [float]
 === 설명
-Sets the data rate in bits per second (baud) for serial data transmission. For communicating with the computer, use one of these rates: 300, 600, 1200, 2400, 4800, 9600, 14400, 19200, 28800, 38400, 57600, or 115200. You can, however, specify other rates - for example, to communicate over pins 0 and 1 with a component that requires a particular baud rate.
+Sets the data rate in bits per second (baud) for serial data transmission. For communicating with Serial Monitor, make sure to use one of the baud rates listed in the menu at the bottom right corner of its screen. You can, however, specify other rates - for example, to communicate over pins 0 and 1 with a component that requires a particular baud rate.
 
 An optional second argument configures the data, parity, and stop bits. The default is 8 data bits, no parity, one stop bit.
 [%hardbreaks]


### PR DESCRIPTION
Other baud rates have been added to Serial Monitor, and some on the list are not supported. Rather than make the long list even longer, I think it's better to remove it altogether and replace it with general instructions.

Fixes https://github.com/arduino/reference-ko/issues/145