### PR TITLE
Update serialEvent() hardware support documentation

### DIFF
--- a/Language/Functions/Communication/Serial/serialEvent.adoc
+++ b/Language/Functions/Communication/Serial/serialEvent.adoc
@@ -15,8 +15,6 @@ title: serialEvent()
 [float]
 === 설명
 Called when data is available. Use `Serial.read()` to capture this data.
-
-NB : Currently, `serialEvent()` is not compatible with the Esplora, Leonardo, or Micro
 [%hardbreaks]
 
 
@@ -55,6 +53,23 @@ Nothing
 
 --
 // OVERVIEW SECTION ENDS
+
+
+// HOW TO USE SECTION STARTS
+[#howtouse]
+--
+
+[float]
+=== Notes and Warnings
+`serialEvent()` doesn't work on the Leonardo or Micro.
+
+`serialEvent()` and `serialEvent1()` don't work on the Arduino SAMD Boards
+
+`serialEvent()`, `serialEvent1()``serialEvent2()`, and `serialEvent3()`  don't work on the Arduino Due.
+[%hardbreaks]
+
+--
+// HOW TO USE SECTION ENDS
 
 
 // SEE ALSO SECTION


### PR DESCRIPTION
serialEvent*() doesn't work on the SAMD and SAM boards.

Strangely, the ARC32 core (101) has a call to serialEvent(), but not one to serialEvent1(). I don't own a 101 so I can't verify any level of support on that board.

Fixes https://github.com/arduino/reference-ko/issues/174