### PR TITLE
Improve wording of Stream class description

### DIFF
--- a/Language/Functions/Communication/Stream/streamAvailable.adoc
+++ b/Language/Functions/Communication/Stream/streamAvailable.adoc
@@ -15,7 +15,7 @@ title: Stream.available()
 === 설명
 `available()` gets the number of bytes available in the stream. This is only for bytes that have already arrived.
 
-This function is part of the Stream class, and is called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[Stream class] main page for more information.
+This function is part of the Stream class, and can be called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[Stream class] main page for more information.
 [%hardbreaks]
 
 

--- a/Language/Functions/Communication/Stream/streamFind.adoc
+++ b/Language/Functions/Communication/Stream/streamFind.adoc
@@ -16,7 +16,7 @@ title: Stream.find()
 === 설명
 `find()` reads data from the stream until the target string of given length is found The function returns true if target string is found, false if timed out.
 
-This function is part of the Stream class, and is called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[stream class] main page for more information.
+This function is part of the Stream class, and can be called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[stream class] main page for more information.
 [%hardbreaks]
 
 

--- a/Language/Functions/Communication/Stream/streamFindUntil.adoc
+++ b/Language/Functions/Communication/Stream/streamFindUntil.adoc
@@ -18,7 +18,7 @@ title: Stream.findUntil()
 
 The function returns true if target string is found, false if timed out
 
-This function is part of the Stream class, and is called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[Stream class] main page for more information.
+This function is part of the Stream class, and can be called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[Stream class] main page for more information.
 [%hardbreaks]
 
 

--- a/Language/Functions/Communication/Stream/streamFlush.adoc
+++ b/Language/Functions/Communication/Stream/streamFlush.adoc
@@ -16,7 +16,7 @@ title: Stream.flush()
 === 설명
 `flush()` clears the buffer once all outgoing characters have been sent.
 
-This function is part of the Stream class, and is called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[stream class] main page for more information.
+This function is part of the Stream class, and can be called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[stream class] main page for more information.
 [%hardbreaks]
 
 

--- a/Language/Functions/Communication/Stream/streamParseFloat.adoc
+++ b/Language/Functions/Communication/Stream/streamParseFloat.adoc
@@ -16,7 +16,7 @@ title: Stream.parseFloat()
 === 설명
 `parseFloat()` returns the first valid floating point number from the current position. Initial characters that are not digits (or the minus sign) are skipped. `parseFloat()` is terminated by the first character that is not a floating point number.
 
-This function is part of the Stream class, and is called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[Stream class] main page for more informatio
+This function is part of the Stream class, and can be called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[Stream class] main page for more informatio
 [%hardbreaks]
 
 

--- a/Language/Functions/Communication/Stream/streamParseInt.adoc
+++ b/Language/Functions/Communication/Stream/streamParseInt.adoc
@@ -22,7 +22,7 @@ In particular:
 * Parsing stops when no characters have been read for a configurable time-out value, or a non-digit is read; +
 * If no valid digits were read when the time-out (see link:../streamsettimeout[Stream.setTimeout()]) occurs, 0 is returned;
 
-This function is part of the Stream class, and is called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[Stream class] main page for more information.
+This function is part of the Stream class, and can be called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[Stream class] main page for more information.
 [%hardbreaks]
 
 

--- a/Language/Functions/Communication/Stream/streamPeek.adoc
+++ b/Language/Functions/Communication/Stream/streamPeek.adoc
@@ -16,7 +16,7 @@ title: Stream.peek()
 === 설명
 Read a byte from the file without advancing to the next one. That is, successive calls to `peek()` will return the same value, as will the next call to `read()`.
 
-This function is part of the Stream class, and is called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[Stream class] main page for more information.
+This function is part of the Stream class, and can be called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[Stream class] main page for more information.
 [%hardbreaks]
 
 

--- a/Language/Functions/Communication/Stream/streamRead.adoc
+++ b/Language/Functions/Communication/Stream/streamRead.adoc
@@ -16,7 +16,7 @@ title: Stream.read()
 === 설명
 `read()` reads characters from an incoming stream to the buffer.
 
-This function is part of the Stream class, and is called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[stream class] main page for more information.
+This function is part of the Stream class, and can be called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[stream class] main page for more information.
 [%hardbreaks]
 
 

--- a/Language/Functions/Communication/Stream/streamReadBytes.adoc
+++ b/Language/Functions/Communication/Stream/streamReadBytes.adoc
@@ -18,7 +18,7 @@ title: Stream.readBytes()
 
 `readBytes()` returns the number of bytes placed in the buffer. A 0 means no valid data was found.
 
-This function is part of the Stream class, and is called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[Stream class] main page for more information.
+This function is part of the Stream class, and can be called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[Stream class] main page for more information.
 [%hardbreaks]
 
 

--- a/Language/Functions/Communication/Stream/streamReadBytesUntil.adoc
+++ b/Language/Functions/Communication/Stream/streamReadBytesUntil.adoc
@@ -18,7 +18,7 @@ title: Stream.readBytesUntil()
 
 `readBytesUntil()` returns the number of bytes placed in the buffer. A 0 means no valid data was found.
 
-This function is part of the Stream class, and is called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[Stream class] main page for more information.
+This function is part of the Stream class, and can be called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[Stream class] main page for more information.
 [%hardbreaks]
 
 

--- a/Language/Functions/Communication/Stream/streamReadString.adoc
+++ b/Language/Functions/Communication/Stream/streamReadString.adoc
@@ -16,7 +16,7 @@ title: Stream.readString()
 === 설명
 `readString()` reads characters from a stream into a String. The function terminates if it times out (see link:../streamsettimeout[setTimeout()]).
 
-This function is part of the Stream class, and is called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[Stream class] main page for more information.
+This function is part of the Stream class, and can be called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[Stream class] main page for more information.
 [%hardbreaks]
 
 

--- a/Language/Functions/Communication/Stream/streamReadStringUntil.adoc
+++ b/Language/Functions/Communication/Stream/streamReadStringUntil.adoc
@@ -16,7 +16,7 @@ title: Stream.readStringUntil()
 === 설명
 `readStringUntil()` reads characters from a stream into a String. The function terminates if the terminator character is detected or it times out (see link:../streamsettimeout[setTimeout()]).
 
-This function is part of the Stream class, and is called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[Stream class] main page for more information.
+This function is part of the Stream class, and can be called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[Stream class] main page for more information.
 [%hardbreaks]
 
 

--- a/Language/Functions/Communication/Stream/streamSetTimeout.adoc
+++ b/Language/Functions/Communication/Stream/streamSetTimeout.adoc
@@ -14,7 +14,7 @@ title: Stream.setTimeout()
 
 [float]
 === 설명
-`setTimeout()` sets the maximum milliseconds to wait for stream data, it defaults to 1000 milliseconds. This function is part of the Stream class, and is called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[Stream class] main page for more information.
+`setTimeout()` sets the maximum milliseconds to wait for stream data, it defaults to 1000 milliseconds. This function is part of the Stream class, and can be called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[Stream class] main page for more information.
 [%hardbreaks]
 
 


### PR DESCRIPTION
Rather than saying "This function is part of the Stream class, and is called by any class that inherits from it", it's more accurate and less confusing to say "This function is part of the Stream class, and can be called by any class that inherits from it".

Fixes https://github.com/arduino/reference-ko/issues/177