### PR TITLE
Consistently document inheritance from Stream class

### DIFF
--- a/Language/Functions/Communication/Serial/available.adoc
+++ b/Language/Functions/Communication/Serial/available.adoc
@@ -14,7 +14,9 @@ title: Serial.available()
 
 [float]
 === 설명
-Get the number of bytes (characters) available for reading from the serial port. This is data that's already arrived and stored in the serial receive buffer (which holds 64 bytes). `available()` inherits from the Stream utility class.
+Get the number of bytes (characters) available for reading from the serial port. This is data that's already arrived and stored in the serial receive buffer (which holds 64 bytes).
+
+`Serial.available()` inherits from the link:../../stream[Stream] utility class.
 [%hardbreaks]
 
 

--- a/Language/Functions/Communication/Serial/peek.adoc
+++ b/Language/Functions/Communication/Serial/peek.adoc
@@ -14,7 +14,9 @@ title: Serial.peek()
 
 [float]
 === 설명
-Returns the next byte (character) of incoming serial data without removing it from the internal serial buffer. That is, successive calls to `peek()` will return the same character, as will the next call to `read()`. `peek()` inherits from the link:../../stream[Stream] utility class.
+Returns the next byte (character) of incoming serial data without removing it from the internal serial buffer. That is, successive calls to `peek()` will return the same character, as will the next call to `read()`.
+
+`Serial.peek()` inherits from the link:../../stream[Stream] utility class.
 [%hardbreaks]
 
 

--- a/Language/Functions/Communication/Serial/readString.adoc
+++ b/Language/Functions/Communication/Serial/readString.adoc
@@ -16,8 +16,7 @@ title: Serial.readString()
 === 설명
 `Serial.readString()` reads characters from the serial buffer into a String. The function terminates if it times out (see link:../settimeout[setTimeout()]).
 
-This function is part of the Stream class, and is called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[Stream class] main page for more information.
-
+`Serial.readString()` inherits from the link:../../stream[Stream] utility class.
 [%hardbreaks]
 
 

--- a/Language/Functions/Communication/Serial/readStringUntil.adoc
+++ b/Language/Functions/Communication/Serial/readStringUntil.adoc
@@ -16,8 +16,7 @@ title: Serial.readStringUntil()
 === 설명
 `readStringUntil()` reads characters from the serial buffer into a String. The function terminates if it times out (see link:../settimeout[setTimeout()]).
 
-This function is part of the Stream class, and is called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[Stream class] main page for more information.
-
+`Serial.readStringUntil()` inherits from the link:../../stream[Stream] utility class.
 [%hardbreaks]
 
 


### PR DESCRIPTION
A standard wording was established in the other Serial reference pages, but not followed by all of them.

Fixes https://github.com/arduino/reference-ko/issues/178