### PR TITLE
Add missing timeout documentation to Stream functions

### DIFF
--- a/Language/Functions/Communication/Serial/parseFloat.adoc
+++ b/Language/Functions/Communication/Serial/parseFloat.adoc
@@ -14,7 +14,7 @@ title: Serial.parseFloat()
 
 [float]
 === 설명
-`Serial.parseFloat()` returns the first valid floating point number from the Serial buffer. Characters that are not digits (or the minus sign) are skipped. `parseFloat()` is terminated by the first character that is not a floating point number.
+`Serial.parseFloat()` returns the first valid floating point number from the Serial buffer. Characters that are not digits (or the minus sign) are skipped. `parseFloat()` is terminated by the first character that is not a floating point number. The function terminates if it times out (see link:../settimeout[Serial.setTimeout()]).
 
 `Serial.parseFloat()` inherits from the link:../../stream[Stream] utility class.
 [%hardbreaks]

--- a/Language/Functions/Communication/Serial/parseInt.adoc
+++ b/Language/Functions/Communication/Serial/parseInt.adoc
@@ -14,7 +14,9 @@ title: Serial.parseInt()
 
 [float]
 === 설명
-Looks for the next valid integer in the incoming serial `stream.parseInt()` inherits from the link:../../stream[Stream] utility class.
+Looks for the next valid integer in the incoming serial. The function terminates if it times out (see link:../settimeout[Serial.setTimeout()]).
+
+`Serial.parseInt()` inherits from the link:../../stream[Stream] utility class.
 
 
 In particular:

--- a/Language/Functions/Communication/Stream/streamFind.adoc
+++ b/Language/Functions/Communication/Stream/streamFind.adoc
@@ -14,7 +14,7 @@ title: Stream.find()
 
 [float]
 === 설명
-`find()` reads data from the stream until the target string of given length is found The function returns true if target string is found, false if timed out.
+`find()` reads data from the stream until the target is found. The function returns true if target is found, false if timed out (see ../streamsettimeout[Stream.setTimeout()]).
 
 This function is part of the Stream class, and is called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[stream class] main page for more information.
 [%hardbreaks]

--- a/Language/Functions/Communication/Stream/streamFindUntil.adoc
+++ b/Language/Functions/Communication/Stream/streamFindUntil.adoc
@@ -14,7 +14,7 @@ title: Stream.findUntil()
 
 [float]
 === 설명
-`findUntil()` reads data from the stream until the target string of given length or terminator string is found.
+`findUntil()` reads data from the stream until the target string of given length or terminator string is found, or it times out (see ../streamsettimeout[Stream.setTimeout()]).
 
 The function returns true if target string is found, false if timed out
 

--- a/Language/Functions/Communication/Stream/streamParseFloat.adoc
+++ b/Language/Functions/Communication/Stream/streamParseFloat.adoc
@@ -14,7 +14,7 @@ title: Stream.parseFloat()
 
 [float]
 === 설명
-`parseFloat()` returns the first valid floating point number from the current position. Initial characters that are not digits (or the minus sign) are skipped. `parseFloat()` is terminated by the first character that is not a floating point number.
+`parseFloat()` returns the first valid floating point number from the current position. Initial characters that are not digits (or the minus sign) are skipped. `parseFloat()` is terminated by the first character that is not a floating point number. The function terminates if it times out (see ../streamsettimeout[Stream.setTimeout()]).
 
 This function is part of the Stream class, and is called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[Stream class] main page for more informatio
 [%hardbreaks]


### PR DESCRIPTION
Some of the Stream class functions that time out did not document this fact.

Fixes https://github.com/arduino/reference-ko/issues/179