### PR TITLE
Document handling of terminator in Stream read*Until functions

### DIFF
--- a/Language/Functions/Communication/Serial/readBytesUntil.adoc
+++ b/Language/Functions/Communication/Serial/readBytesUntil.adoc
@@ -48,6 +48,19 @@ Serial.readBytesUntil() reads characters from the serial buffer into an array. T
 // OVERVIEW SECTION ENDS
 
 
+// HOW TO USE SECTION STARTS
+[#howtouse]
+--
+
+[float]
+=== Notes and Warnings
+The terminator character is discarded from the serial buffer.
+[%hardbreaks]
+
+--
+// HOW TO USE SECTION ENDS
+
+
 // SEE ALSO SECTION
 [#see_also]
 --

--- a/Language/Functions/Communication/Serial/readStringUntil.adoc
+++ b/Language/Functions/Communication/Serial/readStringUntil.adoc
@@ -32,10 +32,23 @@ This function is part of the Stream class, and is called by any class that inher
 
 [float]
 === 반환
-The entire String read from the serial buffer, until the terminator character is detected
+The entire String read from the serial buffer, up to the terminator character
 
 --
 // OVERVIEW SECTION ENDS
+
+
+// HOW TO USE SECTION STARTS
+[#howtouse]
+--
+
+[float]
+=== Notes and Warnings
+The terminator character is discarded from the serial buffer.
+[%hardbreaks]
+
+--
+// HOW TO USE SECTION ENDS
 
 
 // SEE ALSO SECTION

--- a/Language/Functions/Communication/Stream/streamReadBytesUntil.adoc
+++ b/Language/Functions/Communication/Stream/streamReadBytesUntil.adoc
@@ -14,7 +14,7 @@ title: Stream.readBytesUntil()
 
 [float]
 === 설명
-`readBytesUntil()` reads characters from a stream into a buffer. The function terminates if the terminator character is detected, the determined length has been read, or it times out (see link:../streamsettimeout[setTimeout()]).
+`readBytesUntil()` reads characters from a stream into a buffer. The function terminates if the terminator character is detected, the determined length has been read, or it times out (see link:../streamsettimeout[setTimeout()]). The function returns the characters up to the last character before the supplied terminator. The terminator itself is not returned in the buffer.
 
 `readBytesUntil()` returns the number of bytes placed in the buffer. A 0 means no valid data was found.
 
@@ -43,3 +43,16 @@ The number of bytes placed in the buffer.
 
 --
 // OVERVIEW SECTION ENDS
+
+
+// HOW TO USE SECTION STARTS
+[#howtouse]
+--
+
+[float]
+=== Notes and Warnings
+The terminator character is discarded from the stream.
+[%hardbreaks]
+
+--
+// HOW TO USE SECTION ENDS

--- a/Language/Functions/Communication/Stream/streamReadStringUntil.adoc
+++ b/Language/Functions/Communication/Stream/streamReadStringUntil.adoc
@@ -31,7 +31,21 @@ This function is part of the Stream class, and is called by any class that inher
 
 [float]
 === 반환
-The entire String read from a stream, until the terminator character is detected.
+The entire String read from a stream, up to the terminator character
 
 --
 // OVERVIEW SECTION ENDS
+
+
+// HOW TO USE SECTION STARTS
+[#howtouse]
+--
+
+[float]
+=== Notes and Warnings
+The terminator character is discarded from the stream.
+[%hardbreaks]
+
+--
+// HOW TO USE SECTION ENDS
+


### PR DESCRIPTION
- The returned read does not include the terminator.
- The terminator is discarded from the stream.

Fixes https://github.com/arduino/reference-ko/issues/180