### PR TITLE
Declare counter variable in for statements

### DIFF
--- a/Language/Structure/Control Structure/break.adoc
+++ b/Language/Structure/Control Structure/break.adoc
@@ -36,7 +36,7 @@ subCategories: [ "제어 구조" ]
 [source,arduino]
 ----
 int threshold = 40;
-for (x = 0; x < 255; x ++) {
+for (int x = 0; x < 255; x ++) {
   analogWrite(PWMpin, x);
   sens = analogRead(sensorPin);
   if (sens > threshold) { // bail out on sensor detect

--- a/Language/Structure/Control Structure/continue.adoc
+++ b/Language/Structure/Control Structure/continue.adoc
@@ -37,7 +37,7 @@ subCategories: [ "제어 구조" ]
 아래 코드는 0에서 255까지의 코드 값을 `PWMpin` 에 쓰지만, 41에서 119 의 범위 값은 건너뛴다.
 [source,arduino]
 ----
-for (x = 0; x <= 255; x ++) {
+for (int x = 0; x <= 255; x ++) {
   if (x > 40 && x < 120) {  // 값 중 건너뛸 것을 만듦
     continue;
   }

--- a/Language/Variables/Data Types/array.adoc
+++ b/Language/Variables/Data Types/array.adoc
@@ -73,8 +73,7 @@ BASIC, 자바와 달리, C++ 컴파일러는 배열 액세스가 선언한 배�
 
 [source,arduino]
 ----
-int i;
-for (i = 0; i < 5; i = i + 1) {
+for (byte i = 0; i < 5; i = i + 1) {
   Serial.println(myPins[i]);
 }
 ----

--- a/Language/Variables/Utilities/PROGMEM.adoc
+++ b/Language/Variables/Utilities/PROGMEM.adoc
@@ -71,7 +71,6 @@ const PROGMEM  uint16_t charSet[]  = { 65000, 32796, 16843, 10, 11234};
 const char signMessage[] PROGMEM  = {"I AM PREDATOR,  UNSEEN COMBATANT. CREATED BY THE UNITED STATES DEPART"};
 
 unsigned int displayInt;
-int k;  // counter variable
 char myChar;
 
 
@@ -81,14 +80,14 @@ void setup() {
 
   // put your setup code here, to run once:
   // read back a 2-byte int
-  for (k = 0; k < 5; k++) {
+  for (byte k = 0; k < 5; k++) {
     displayInt = pgm_read_word_near(charSet + k);
     Serial.println(displayInt);
   }
   Serial.println();
 
   // read back a char
-  for (k = 0; k < strlen_P(signMessage); k++) {
+  for (byte k = 0; k < strlen_P(signMessage); k++) {
     myChar =  pgm_read_byte_near(signMessage + k);
     Serial.print(myChar);
   }

--- a/Language/Variables/Utilities/sizeof.adoc
+++ b/Language/Variables/Utilities/sizeof.adoc
@@ -44,14 +44,13 @@ subCategories: [ "유틸리티" ]
 [source,arduino]
 ----
 char myStr[] = "this is a test";
-int i;
 
 void setup() {
   Serial.begin(9600);
 }
 
 void loop() {
-  for (i = 0; i < sizeof(myStr) - 1; i++) {
+  for (byte i = 0; i < sizeof(myStr) - 1; i++) {
     Serial.print(i, DEC);
     Serial.print(" = ");
     Serial.write(myStr[i]);
@@ -69,7 +68,7 @@ void loop() {
 
 [source,arduino]
 ----
-for (i = 0; i < (sizeof(myInts) / sizeof(myInts[0])); i++) {
+for (byte i = 0; i < (sizeof(myInts) / sizeof(myInts[0])); i++) {
   // myInts[i] 가지고 무언가를 함
 }
 ----


### PR DESCRIPTION
Declaring the counter variable outside the for statement is done very rarely in actual programming, and only when there is a use for that variable outside the scope of the for loop (which is not the case here). I don't see any value in declaring the variable outside the statement in the example code, as it only teaches bad programming. In some cases, the example code snippets didn't even contain a declaration and so would not compile if copied into a sketch.

Fixes https://github.com/arduino/reference-ko/issues/259