### PR TITLE
Fix inconsistent formatting of See also links

### DIFF
--- a/Language/Structure/Control Structure/while.adoc
+++ b/Language/Structure/Control Structure/while.adoc
@@ -67,7 +67,7 @@ while (var < 200) {
 [role="language"]
 
 [role="example"]
-* #EXAMPLE#	https://arduino.cc/en/Tutorial/WhileLoop[While Loop Tutorial^]
+* #EXAMPLE# https://arduino.cc/en/Tutorial/WhileLoop[While Loop Tutorial^]
 
 --
 // SEE ALSO SECTION ENDS

--- a/Language/Structure/Further Syntax/define.adoc
+++ b/Language/Structure/Further Syntax/define.adoc
@@ -86,8 +86,8 @@ subCategories: [ "추가 문법" ]
 === 더보기
 
 [role="language"]
-* #LANGUAGE#	link:../../../variables/variable-scope\--qualifiers/const[const]
-* #LANGUAGE#	link:../../../variables/constants/constants[Constants]
+* #LANGUAGE# link:../../../variables/variable-scope\--qualifiers/const[const]
+* #LANGUAGE# link:../../../variables/constants/constants[Constants]
 
 --
 // SEE ALSO SECTION ENDS


### PR DESCRIPTION
These links use a tab separator between the tag and link, contrary to the standard established in the reference sample.

Fixes https://github.com/arduino/reference-ko/issues/260