### PR TITLE
Fix link to PitchFollower tutorial

### DIFF
--- a/Language/Functions/Advanced IO/tone.adoc
+++ b/Language/Functions/Advanced IO/tone.adoc
@@ -77,7 +77,7 @@ subCategories: [ "고급 입출력" ]
 
 [role="example"]
 * #EXAMPLE# http://arduino.cc/en/Tutorial/Tone[Tone^]
-* #EXAMPLE# http://arduino.cc/en/Tutorial/Tone[Pitch follower^]
+* #EXAMPLE# http://arduino.cc/en/Tutorial/tonePitchFollower[Pitch follower^]
 * #EXAMPLE# http://arduino.cc/en/Tutorial/Tone3[Simple Keyboard^]
 * #EXAMPLE# http://arduino.cc/en/Tutorial/Tone4[multiple tones^]
 * #EXAMPLE# http://arduino.cc/en/Tutorial/PWM[PWM^]


### PR DESCRIPTION
Previously, the link pointed to the ToneMelody tutorial, which already has a link on the tone reference page.

Fixes https://github.com/arduino/reference-ko/issues/263