### PR TITLE
Standardize link text

### DIFF
--- a/Language/Functions/Advanced IO/tone.adoc
+++ b/Language/Functions/Advanced IO/tone.adoc
@@ -76,10 +76,10 @@ subCategories: [ "고급 입출력" ]
 * #LANGUAGE# link:../../analog-io/analogwrite[analogWrite()]
 
 [role="example"]
-* #EXAMPLE# http://arduino.cc/en/Tutorial/Tone[Tone^]
-* #EXAMPLE# http://arduino.cc/en/Tutorial/Tone[Pitch follower^]
-* #EXAMPLE# http://arduino.cc/en/Tutorial/Tone3[Simple Keyboard^]
-* #EXAMPLE# http://arduino.cc/en/Tutorial/Tone4[multiple tones^]
+* #EXAMPLE# http://arduino.cc/en/Tutorial/Tone[Tone Melody^]
+* #EXAMPLE# http://arduino.cc/en/Tutorial/tonePitchFollower[Pitch Follower^]
+* #EXAMPLE# http://arduino.cc/en/Tutorial/Tone3[Tone Keyboard^]
+* #EXAMPLE# http://arduino.cc/en/Tutorial/Tone4[Tone Multiple^]
 * #EXAMPLE# http://arduino.cc/en/Tutorial/PWM[PWM^]
 
 --

--- a/Language/Functions/Communication/Serial/serialEvent.adoc
+++ b/Language/Functions/Communication/Serial/serialEvent.adoc
@@ -80,7 +80,7 @@ Nothing
 === 더보기
 
 [role="example"]
-* #EXAMPLE# http://arduino.cc/en/Tutorial/SerialEvent[SerialEvent Tutorial^]
+* #EXAMPLE# http://arduino.cc/en/Tutorial/SerialEvent[Serial Event Tutorial^]
 
 [role="language"]
 * #LANGUAGE# link:../begin[begin()]


### PR DESCRIPTION
I'm following the example of the Tutorials page in how to format the link text for the tutorial links.

Fixes https://github.com/arduino/reference-ko/issues/279