### PR TITLE
Correct syntax section of parseFloat() reference pages

### DIFF
--- a/Language/Functions/Communication/Serial/parseFloat.adoc
+++ b/Language/Functions/Communication/Serial/parseFloat.adoc
@@ -14,7 +14,7 @@ title: Serial.parseFloat()
 
 [float]
 === 설명
-`Serial.parseFloat()` returns the first valid floating point number from the Serial buffer. Characters that are not digits (or the minus sign) are skipped. `parseFloat()` is terminated by the first character that is not a floating point number. The function terminates if it times out (see link:../settimeout[Serial.setTimeout()]).
+`Serial.parseFloat()` returns the first valid floating point number from the Serial buffer. `parseFloat()` is terminated by the first character that is not a floating point number. The function terminates if it times out (see link:../settimeout[Serial.setTimeout()]).
 
 `Serial.parseFloat()` inherits from the link:../../stream[Stream] utility class.
 [%hardbreaks]
@@ -22,12 +22,21 @@ title: Serial.parseFloat()
 
 [float]
 === 문법
-`Serial.parseFloat()`
+`_Serial_.parseFloat()` +
+`_Serial_.parseFloat(lookahead)` +
+`_Serial_.parseFloat(lookahead, ignore)`
 
 
 [float]
 === 매개변수
-Nothing
+`_Serial_`: serial port object. See the list of available serial ports for each board on the link:../../serial[Serial main page]. +
+`lookahead`: the mode used to look ahead in the stream for a floating point number. Allowed data types: `LookaheadMode`. Allowed `lookahead` values:
+
+* `SKIP_ALL`: all characters other than a minus sign, decimal point, or digits are ignored when scanning the stream for a floating point number. This is the default mode.
+* `SKIP_NONE`: Nothing is skipped, and the stream is not touched unless the first waiting character is valid.
+* `SKIP_WHITESPACE`: Only tabs, spaces, line feeds, and carriage returns are skipped.
+
+`ignore`: used to skip the indicated char in the search. Used for example to skip thousands divider. Allowed data types: `char`
 
 [float]
 === 반환

--- a/Language/Functions/Communication/Stream/streamParseFloat.adoc
+++ b/Language/Functions/Communication/Stream/streamParseFloat.adoc
@@ -14,22 +14,29 @@ title: Stream.parseFloat()
 
 [float]
 === 설명
-`parseFloat()` returns the first valid floating point number from the current position. Initial characters that are not digits (or the minus sign) are skipped. `parseFloat()` is terminated by the first character that is not a floating point number. The function terminates if it times out (see ../streamsettimeout[Stream.setTimeout()]).
+`parseFloat()` returns the first valid floating point number from the current position. `parseFloat()` is terminated by the first character that is not a floating point number. The function terminates if it times out (see link:../streamsettimeout[Stream.setTimeout()]).
 
-This function is part of the Stream class, and can be called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[Stream class] main page for more informatio
+This function is part of the Stream class, and can be called by any class that inherits from it (Wire, Serial, etc). See the link:../../stream[Stream class] main page for more information.
 [%hardbreaks]
 
 
 [float]
 === 문법
-`stream.parseFloat(list)`
+`stream.parseFloat()` +
+`stream.parseFloat(lookahead)` +
+`stream.parseFloat(lookahead, ignore)`
 
 
 [float]
 === 매개변수
-`stream` : an instance of a class that inherits from Stream.
+`stream` : an instance of a class that inherits from Stream. +
+`lookahead`: the mode used to look ahead in the stream for a floating point number. Allowed data types: `LookaheadMode`. Allowed `lookahead` values:
 
-`list` : the stream to check for floats (`char`)
+* `SKIP_ALL`: all characters other than a minus sign, decimal point, or digits are ignored when scanning the stream for a floating point number. This is the default mode.
+* `SKIP_NONE`: Nothing is skipped, and the stream is not touched unless the first waiting character is valid.
+* `SKIP_WHITESPACE`: Only tabs, spaces, line feeds, and carriage returns are skipped.
+
+`ignore`: used to skip the indicated char in the search. Used for example to skip thousands divider. Allowed data types: `char`
 
 [float]
 === 반환


### PR DESCRIPTION
Both the `Stream.parseFloat()` and `Serial.parseFloat()` reference pages had erroneous information in their syntax documentation.

Reference:
https://github.com/arduino/ArduinoCore-API/blob/1.0.0/api/Stream.h#L93

Fixes https://github.com/arduino/reference-ko/issues/290