### PR TITLE
Be consistent with the use of "Tutorial" in link text

### DIFF
--- a/Language/Functions/Communication/Serial/serialEvent.adoc
+++ b/Language/Functions/Communication/Serial/serialEvent.adoc
@@ -80,7 +80,7 @@ Nothing
 === 더보기
 
 [role="example"]
-* #EXAMPLE# http://arduino.cc/en/Tutorial/SerialEvent[SerialEvent Tutorial^]
+* #EXAMPLE# http://arduino.cc/en/Tutorial/SerialEvent[SerialEvent^]
 
 [role="language"]
 * #LANGUAGE# link:../begin[begin()]

--- a/Language/Structure/Control Structure/while.adoc
+++ b/Language/Structure/Control Structure/while.adoc
@@ -67,7 +67,7 @@ while (var < 200) {
 [role="language"]
 
 [role="example"]
-* #EXAMPLE#	https://arduino.cc/en/Tutorial/WhileLoop[While Loop Tutorial^]
+* #EXAMPLE#	https://arduino.cc/en/Tutorial/WhileLoop[While Loop^]
 
 --
 // SEE ALSO SECTION ENDS


### PR DESCRIPTION
These two tutorial links are no different from the many other example links on the other reference pages, yet they have the word "Tutorial" added, contrary to the standard established in the reference samples. There are some other instances of the use of "Tutorial" in the link text, but in those cases the link does lead to more of a general tutorial than a standard tutorial for an example sketch, so I have left those as is.

Fixes https://github.com/arduino/reference-ko/issues/292