### PR TITLE
Convert UTF-8 BOM to UTF-8 file encoding

### DIFF
--- a/Language/Variables/Data Types/String/Functions/charAt.adoc
+++ b/Language/Variables/Data Types/String/Functions/charAt.adoc
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "charAt()"
 categories: [ "Data Types" ]
 subCategories: [ "스트링개체 함수" ]

--- a/Language/Variables/Data Types/String/Operators/greaterThanOrEqualTo.adoc
+++ b/Language/Variables/Data Types/String/Operators/greaterThanOrEqualTo.adoc
@@ -1,4 +1,4 @@
-﻿---
+---
 title: ">="
 title_expanded: 더 크거나 같은
 categories: [ "Data Types" ]


### PR DESCRIPTION
Use consistent file encoding in all files following the example of the sample reference pages.